### PR TITLE
[Task-5] Rename epic to feature. Fix some wording in feature_issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_issue.md
+++ b/.github/ISSUE_TEMPLATE/feature_issue.md
@@ -1,11 +1,11 @@
 ---
-name: Epic
-about: A task large enough that it needs to be divided into smaller tasks. It will usually be labeled as `enhancement`, also know as feature.
+name: Feature
+about: A task large enough that it needs to be divided into smaller tasks. It will usually be labeled as `enhancement`, also know as epic.
 ---
 
 <!-- Issue title should mirror the Epic/Feature Title -->
 
-# Epic Title
+# Feature Title
 
 Feature: Some Task title
 
@@ -15,7 +15,7 @@ This Feature will...
 
 ## List of Tasks (Complete in order) with experience Notes
 
-<!-- The linik below should link to its Epic parent -->
+<!-- The linik below should link to its feature parent -->
 
 - [ ] #1 
  - Defines the section and item nested structures first; Then think about the navigation, which is the function (or the feature you want to apply when selecting on the item), and expand the properties based on that.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 ## Summary
 
-Give the basica abstraction withe issue number/link here.
+Give the basic abstraction withe issue number/link here.
 
-### (Optiona)Why do we need this?
-- Long descrption of PR
+### (Optional)Why do we need this?
+- Long description of PR
 - Why are we doing this?
 - Any context or related work?
 
@@ -31,10 +31,10 @@ Give the basica abstraction withe issue number/link here.
 ## Contributor Checklist
 
 - Tested on:
- - [ ] Simulator
- - [ ] Device
+    - [ ] Simulator
+    - [ ] Device
 - [ ] No additional warning introduced
-- [ ] Code was formatted <!-- (Build in Xcode or mannually run `Scripts/format.sh`) -->
+- [ ] Code was formatted <!-- (Build in Xcode or manually run `Scripts/format.sh`) -->
 - [ ] Add github labels
 - [ ] Tests
 - [ ] Changes Behind DevSwitch
@@ -49,7 +49,7 @@ Consider decorating your comments: https://conventionalcomments.org/
 - [ ] Appropriate Architectures
 - [ ] Appropriate Tests
 - [ ] Accessibility Inspector audit or no UI impact
-- [ ] Call out any nonobvious regression areas
+- [ ] Call out any non-obvious regression areas
 - [ ] Changes Behind DevSwitch
 
 


### PR DESCRIPTION
This PR fixes the naming of `epic` templates to `feature`. Fix some typos in PR templates.